### PR TITLE
Fixups to fatfs-fstab commit

### DIFF
--- a/samples/subsys/fs/fatfs_fstab/src/main.c
+++ b/samples/subsys/fs/fatfs_fstab/src/main.c
@@ -13,29 +13,62 @@
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 
+#define AUTOMOUNT_NODE DT_NODELABEL(ffs1)
+FS_FSTAB_DECLARE_ENTRY(AUTOMOUNT_NODE);
+
+#define FILE_PATH "/RAM:/hello.txt"
+
 int main(void)
 {
 	struct fs_file_t file;
 	int rc;
 	static const char data[] = "Hello";
+	/* You can get direct mount point to automounted node too */
+	struct fs_mount_t *auto_mount_point = &FS_FSTAB_ENTRY(AUTOMOUNT_NODE);
+	struct fs_dirent stat;
 
 	fs_file_t_init(&file);
-	rc = fs_open(&file, "/RAM:/hello.txt", FS_O_CREATE | FS_O_WRITE);
+
+	rc = fs_open(&file, FILE_PATH, FS_O_CREATE | FS_O_WRITE);
 	if (rc != 0) {
 		LOG_ERR("Accessing filesystem failed");
 		return rc;
 	}
+
 	rc = fs_write(&file, data, strlen(data));
 	if (rc != strlen(data)) {
 		LOG_ERR("Writing filesystem failed");
 		return rc;
 	}
+
 	rc = fs_close(&file);
 	if (rc != 0) {
 		LOG_ERR("Closing file failed");
 		return rc;
 	}
 
+	/* You can unmount the automount node */
+	rc = fs_unmount(auto_mount_point);
+	if (rc != 0) {
+		LOG_ERR("Failed to do unmount");
+		return rc;
+	};
+
+	/* And mount it back */
+	rc = fs_mount(auto_mount_point);
+	if (rc != 0) {
+		LOG_ERR("Failed to remount the auto-mount node");
+		return rc;
+	}
+
+	/* Is the file still there? */
+	rc = fs_stat(FILE_PATH, &stat);
+	if (rc != 0) {
+		LOG_ERR("File status check failed %d", rc);
+		return rc;
+	}
+
 	LOG_INF("Filesystem access successful");
+
 	return 0;
 }

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -559,7 +559,6 @@ static const struct fs_file_system_t fatfs_fs = {
 
 #define DT_DRV_COMPAT zephyr_fstab_fatfs
 
-#ifdef CONFIG_FS_FATFS_FSTAB_AUTOMOUNT
 #define DEFINE_FS(inst)                                                                            \
 	BUILD_ASSERT(DT_INST_PROP(inst, disk_access), "FATFS needs disk-access");                  \
 	BUILD_ASSERT(!DT_INST_PROP(inst, read_only),                                               \
@@ -567,7 +566,7 @@ static const struct fs_file_system_t fatfs_fs = {
 	BUILD_ASSERT(!DT_INST_PROP(inst, no_format),                                               \
 		     "NO_FORMAT not supported for individual instanzes FS_FATFS_MKFS");            \
 	static FATFS fs_data_##inst;                                                               \
-	static struct fs_mount_t FS_FSTAB_ENTRY(DT_DRV_INST(inst)) = {                             \
+	struct fs_mount_t FS_FSTAB_ENTRY(DT_DRV_INST(inst)) = {                                    \
 		.type = FS_FATFS,                                                                  \
 		.mnt_point = DT_INST_PROP(inst, mount_point),                                      \
 		.fs_data = &fs_data_##inst,                                                        \
@@ -577,6 +576,7 @@ static const struct fs_file_system_t fatfs_fs = {
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_FS);
 
+#ifdef CONFIG_FS_FATFS_FSTAB_AUTOMOUNT
 #define REFERENCE_MOUNT(inst) (&FS_FSTAB_ENTRY(DT_DRV_INST(inst))),
 
 static void automount_if_enabled(struct fs_mount_t *mountp)


### PR DESCRIPTION
There are two fixups:
 - one that fixes my mistake, where I have insisted on moving ifdef, that unfortunately made fstab entries unavailable for users that do not use automount
 - one that modifies sample with unmount and remount of automounted system